### PR TITLE
Remove deprecated 'bottle :unneeded'

### DIFF
--- a/Formula/md2confl.rb
+++ b/Formula/md2confl.rb
@@ -7,7 +7,6 @@ class Md2confl < Formula
   homepage "https://github.com/kentaro-m/md2confl"
   version "0.4.1"
   license "MIT"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Formula parameter `bottle :unneeded` has been deprecated.

References:
- https://github.com/Homebrew/brew/commit/f65d525
- https://github.com/Homebrew/brew/pull/11239